### PR TITLE
chore: add GitHub action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,30 @@
+name: 'php-smelly-code-detector'
+description: 'Action to inspect smelly code in PHP projects'
+inputs:
+
+  path:
+    description: 'Project path'
+    required: true
+
+  php-version:
+    description: 'PHP version to use (supports 8.0 and above)'
+    required: false
+    default: '8.3'
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Initialize PHP ${{env.PHP_VERSION}}
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{env.PHP_VERSION}}
+        tools: degraciamathieu/php-smelly-code-detector
+      env:
+        PHP_VERSION: ${{ inputs.php-version }}
+
+    - name: Inspect code
+      run: smelly-code-detector inspect-method ${{env.SOURCE_PATH}}
+      shell: bash
+      env:
+        SOURCE_PATH: ${{ inputs.path }}


### PR DESCRIPTION
To automate smelly-code-detector inspection, following PR add a GitHub Action.

This revision is standalone, installing PHP & running `smelly-code-detector` script.

The action is available as : `abenevaut/php-smelly-code-detector@feat/githubaction`
(This action is loaded from `abenevaut/php-smelly-code-detector` repository in branch `feat/githubaction` => from the PR)

Usage:
```
name: php-smelly-code-detector-test

on:
  workflow_dispatch:

env:
  php_version: 8.3

jobs:

  publish-pages:
    runs-on: ubuntu-latest
    steps:

      - name: Checkout project
        uses: actions/checkout@v4
        with:
          fetch-depth: 0

      - name: Generate static pages
        uses: abenevaut/php-smelly-code-detector@feat/githubaction
        with:
          path: ${{ github.workspace }}/laravel-asana/src
          php-version: ${{ env.php_version }}
```

output is available here : https://github.com/abenevaut/experimental/actions/runs/13571341164/job/37936882942#step:3:43

Once merged, the action will usable as `DeGraciaMathieu/php-smelly-code-detector@master`.

In this PR, only 2 arguments are working, `path` required for smelly-code-detector and `php-version` the PHP version you want to use for inspection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an automated GitHub Action to inspect PHP projects for potential code quality issues.
	- The action supports customizable settings, including specifying a project path and choosing a PHP version (defaulting to 8.3), ensuring streamlined, automated code inspections for improved project quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->